### PR TITLE
Redesign home page with interactive meal planner UI

### DIFF
--- a/MealMate/Pages/Dishes/Index.cshtml
+++ b/MealMate/Pages/Dishes/Index.cshtml
@@ -1,15 +1,15 @@
 @page
 @model MealMate.Pages.Dishes.IndexModel
 @{
-    ViewData["Title"] = "Блюда";
+    ViewData["Title"] = "Редактирование блюд";
 }
 
 <div class="dashboard-grid">
     <section class="section-card">
         <div class="section-header">
             <div>
-                <h1 class="section-title">Добавить новое блюдо</h1>
-                <p class="section-subtitle">Сохраните рецепт, укажите продукты и привяжите его к нужной группе.</p>
+                <h1 class="section-title">Редактор блюд</h1>
+                <p class="section-subtitle">Добавляйте рецепты, назначайте продукты и закрепляйте блюда за коллекциями.</p>
             </div>
         </div>
 
@@ -81,8 +81,8 @@
     <section class="section-card">
         <div class="section-header">
             <div>
-                <h2 class="section-title">Коллекция блюд</h2>
-                <p class="section-subtitle">Все рецепты с описаниями и привязками к группам.</p>
+                <h2 class="section-title">Текущие блюда</h2>
+                <p class="section-subtitle">Редактируйте описания, состав и группировку прямо на этой странице.</p>
             </div>
         </div>
 

--- a/MealMate/Pages/Dishes/Index.cshtml
+++ b/MealMate/Pages/Dishes/Index.cshtml
@@ -138,7 +138,10 @@
                                 }
                             }
                         </div>
-                        <form method="post" asp-page-handler="Delete" asp-route-id="@dish.Id" class="dish-actions" onsubmit="return confirm('Удалить блюдо \"@dish.Name\"?');">
+                    <form method="post" asp-page-handler="Delete" asp-route-id="@dish.Id" class="dish-actions" onsubmit='return confirm("Удалить блюдо @dish.Name?");'>
+                                <form method="post" asp-page-handler="Delete" asp-route-id="@dish.Id" class="dish-actions" onsubmit='return confirm("Удалить блюдо @dish.Name?");'>
+                                    <button type="submit" class="destructive-button">Удалить</button>
+                                </form>
                             <button type="submit" class="destructive-button">Удалить</button>
                         </form>
                     </article>

--- a/MealMate/Pages/Index.cshtml
+++ b/MealMate/Pages/Index.cshtml
@@ -1,162 +1,292 @@
-@page
+@page "{?focusGroup}"
 @model IndexModel
 @{
-    ViewData["Title"] = "Домашний планировщик";
+    ViewData["Title"] = "MealMate — планировщик питания";
+
+    var groups = Model.MealGroups;
+    var selectedGroup = Model.SelectedGroup;
+    var heroDish = selectedGroup?.MealGroupDishes
+        .Select(link => link.Dish)
+        .OrderBy(d => d.Name)
+        .FirstOrDefault();
 }
 
-<div class="dashboard-grid">
-    <section class="section-card hero-card">
-        <div class="hero-content">
-            <div>
-                <h1>MealMate — ваш ежедневный помощник на кухне</h1>
-                <p>Собирайте свои любимые блюда, распределяйте их по группам и следите за тем, что есть в холодильнике.</p>
+<section id="hero" class="hero">
+    <div class="hero-text">
+        <p class="hero-label">Уютный дом начинается с тарелки</p>
+        <h1>MealMate помогает спланировать завтрак, обед и ужин без суеты</h1>
+        <p class="hero-description">
+            Соберите коллекцию любимых блюд, распределите их по группам и моментально решайте, что приготовить.
+            Добавляйте новые идеи, наводите порядок в запасах и держите всю кухонную магию под рукой.
+        </p>
+        <div class="hero-actions">
+            <a class="button primary" asp-page="/Dishes/Index">Собрать меню</a>
+            <a class="button ghost" asp-page="/MealGroups/Index">Коллекции блюд</a>
+        </div>
+        <div class="hero-stats">
+            <div class="stat-card">
+                <span class="stat-number">@Model.TotalMealGroups</span>
+                <span class="stat-label">группы блюд</span>
             </div>
-            <div class="hero-actions">
-                <a class="primary-button" asp-page="/Dishes/Index">Добавить блюдо</a>
-                <a class="secondary-button" asp-page="/Products/Index">Обновить список продуктов</a>
+            <div class="stat-card">
+                <span class="stat-number">@Model.TotalDishes</span>
+                <span class="stat-label">готовых идей</span>
+            </div>
+            <div class="stat-card">
+                <span class="stat-number">@Model.TotalUniqueIngredients</span>
+                <span class="stat-label">уникальных продуктов</span>
             </div>
         </div>
-    </section>
-
-    <section class="section-card">
-        <div class="section-header">
-            <div>
-                <h2 class="section-title">Группы блюд</h2>
-                <p class="section-subtitle">Используйте коллекции, чтобы быстро подобрать идеи для завтрака, обеда или ужина.</p>
-            </div>
-            <a class="primary-button" asp-page="/MealGroups/Index">Управление группами</a>
-        </div>
-
-        <div class="meal-groups">
-            @foreach (var group in Model.MealGroups)
+    </div>
+    <div class="hero-visual">
+        <div class="glass-card">
+            <h3>Сегодняшний выбор</h3>
+            <p class="glass-subtitle">
+                @if (selectedGroup is not null)
+                {
+                    <span>@(selectedGroup.Name)</span>
+                }
+                else
+                {
+                    <span>Добавьте первую группу блюд</span>
+                }
+            </p>
+            @if (heroDish is not null)
             {
-                var color = group.AccentColor ?? "#2563EB";
-                <article class="meal-card" style="--accent-color: @color">
-                    <div class="chip-group">
-                        <span class="pill" style="background: rgba(37, 99, 235, 0.08); color: var(--accent-color);">@group.Name</span>
-                        <span class="pill">@group.MealGroupDishes.Count блюд</span>
-                    </div>
-                    <h3>@group.Description</h3>
-                    @if (group.MealGroupDishes.Count == 0)
+                var heroIngredients = heroDish.DishProducts
+                    .Select(dp => dp.Product?.Name)
+                    .Where(name => !string.IsNullOrWhiteSpace(name))
+                    .Distinct()
+                    .Take(4)
+                    .ToList();
+                <div class="glass-dish">
+                    <h4>@heroDish.Name</h4>
+                    @if (!string.IsNullOrWhiteSpace(heroDish.Description))
                     {
-                        <p class="muted">Пока пусто. Добавьте блюда на странице "Блюда".</p>
+                        <p>@heroDish.Description</p>
                     }
-                    else
+                    @if (heroIngredients.Count > 0)
                     {
-                        <ul class="bullet-list">
-                            @foreach (var dishLink in group.MealGroupDishes.OrderBy(m => m.Dish.Name).Take(4))
+                        <ul>
+                            @foreach (var ingredient in heroIngredients)
                             {
-                                <li>@dishLink.Dish.Name</li>
+                                <li>@ingredient</li>
                             }
                         </ul>
-                        @if (group.MealGroupDishes.Count > 4)
+                    }
+                    @if (heroDish.PreparationMinutes.HasValue)
+                    {
+                        <span class="tag">~@heroDish.PreparationMinutes.Value минут</span>
+                    }
+                </div>
+            }
+            else
+            {
+                <div class="glass-empty">Подберите блюдо и добавьте его в коллекцию.</div>
+            }
+        </div>
+    </div>
+</section>
+
+<section id="groups" class="groups">
+    <header class="section-heading">
+        <div>
+            <p class="section-label">Коллекции</p>
+            <h2>Группы блюд для любого настроения</h2>
+        </div>
+        <p class="section-description">
+            Создавайте подборки блюд для завтрака, обеда, ужина, быстрых перекусов или экспериментов на выходных.
+            Переключайтесь между группами и подбирайте идеальный план.
+        </p>
+    </header>
+    <div class="group-tabs">
+        @foreach (var group in groups)
+        {
+            var isActive = selectedGroup?.Id == group.Id;
+            var accent = !string.IsNullOrWhiteSpace(group.AccentColor) ? group.AccentColor : "#f97316";
+            var groupIngredients = group.MealGroupDishes
+                .SelectMany(link => link.Dish.DishProducts)
+                .Select(dp => dp.Product?.Name)
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Distinct()
+                .Count();
+            var groupBadge = string.IsNullOrWhiteSpace(group.Name) ? "🍽" : group.Name.Substring(0, 1).ToUpperInvariant();
+            <a class="group-tab @(isActive ? "active" : string.Empty)" asp-page="./Index" asp-route-focusGroup="@group.Id" style="--accent-color: @accent">
+                <div class="group-info">
+                    <span class="group-icon">@groupBadge</span>
+                    <div>
+                        <h3>@group.Name</h3>
+                        <p>@(string.IsNullOrWhiteSpace(group.Description) ? "Добавьте описание, чтобы не забыть идею." : group.Description)</p>
+                    </div>
+                </div>
+                <div class="group-meta">
+                    <span>@group.MealGroupDishes.Count блюд</span>
+                    <span>@groupIngredients ингредиентов</span>
+                </div>
+            </a>
+        }
+        <a class="group-tab ghost" asp-page="/MealGroups/Index">
+            <div class="group-info">
+                <span class="group-icon">＋</span>
+                <div>
+                    <h3>Новая группа</h3>
+                    <p>Соберите подборку для нового случая или настроения.</p>
+                </div>
+            </div>
+            <div class="group-meta">
+                <span>Управлять</span>
+            </div>
+        </a>
+    </div>
+</section>
+
+<section id="planner" class="planner">
+    <div class="planner-grid">
+        <div class="dish-list">
+            <header class="section-heading">
+                <div>
+                    <p class="section-label">Меню</p>
+                    <h2>@(selectedGroup is null ? "Выберите группу" : selectedGroup.Name)</h2>
+                </div>
+                @if (selectedGroup is not null)
+                {
+                    <p class="section-description">
+                        @(string.IsNullOrWhiteSpace(selectedGroup.Description) ? "Добавьте описание, чтобы эта подборка была ещё полезнее." : selectedGroup.Description)
+                    </p>
+                }
+            </header>
+            @if (selectedGroup?.MealGroupDishes.Any() == true)
+            {
+                var orderedDishes = selectedGroup.MealGroupDishes
+                    .Select(link => link.Dish)
+                    .OrderBy(d => d.Name)
+                    .ToList();
+                <div class="dish-grid">
+                    @foreach (var dish in orderedDishes)
+                    {
+                        var ingredients = dish.DishProducts
+                            .Select(dp => dp.Product?.Name)
+                            .Where(name => !string.IsNullOrWhiteSpace(name))
+                            .Distinct()
+                            .ToList();
+                        <article class="dish-card">
+                            <header>
+                                <div class="dish-title">
+                                    <span class="dish-icon">🍲</span>
+                                    <h3>@dish.Name</h3>
+                                </div>
+                                <a class="ghost" asp-page="/Dishes/Index" asp-route-focus="@dish.Id">Открыть</a>
+                            </header>
+                            @if (!string.IsNullOrWhiteSpace(dish.Description))
+                            {
+                                <p>@dish.Description</p>
+                            }
+                            @if (ingredients.Count > 0)
+                            {
+                                <ul>
+                                    @foreach (var ingredient in ingredients)
+                                    {
+                                        <li>@ingredient</li>
+                                    }
+                                </ul>
+                            }
+                            <footer>
+                                @if (dish.PreparationMinutes.HasValue)
+                                {
+                                    <span class="tag">@dish.PreparationMinutes.Value минут</span>
+                                }
+                                <a class="recipe-link" asp-page="/Dishes/Index" asp-route-focus="@dish.Id">Редактировать</a>
+                            </footer>
+                        </article>
+                    }
+                </div>
+            }
+            else if (selectedGroup is not null)
+            {
+                <div class="empty-state">
+                    <h3>Пока пусто</h3>
+                    <p>Добавьте первое блюдо в эту группу и MealMate подскажет, что приготовить.</p>
+                    <a class="button primary" asp-page="/Dishes/Index" asp-route-group="@selectedGroup.Id">Добавить блюдо</a>
+                </div>
+            }
+            else
+            {
+                <div class="empty-state">
+                    <h3>Нет выбранной группы</h3>
+                    <p>Создайте коллекцию блюд и начните планировать питание.</p>
+                </div>
+            }
+        </div>
+        <aside class="actions">
+            <div class="form-card">
+                <h3>Добавить блюдо</h3>
+                <p class="form-caption">Заполните карточку и пополните коллекцию свежими идеями.</p>
+                <a class="button primary" asp-page="/Dishes/Create">Новое блюдо</a>
+                <a class="button ghost" asp-page="/Dishes/Index">Все блюда</a>
+            </div>
+            <div class="form-card">
+                <h3>Новая группа</h3>
+                <p class="form-caption">Соберите подборку для нового случая или настроения.</p>
+                <a class="button primary" asp-page="/MealGroups/Create">Создать группу</a>
+                <a class="button ghost" asp-page="/MealGroups/Index">Управление группами</a>
+            </div>
+            @if (Model.HighlightedIngredients.Any())
+            {
+                <div class="ingredient-cloud">
+                    <h3>Частые ингредиенты</h3>
+                    <div class="chips">
+                        @foreach (var ingredient in Model.HighlightedIngredients)
                         {
-                            <p class="muted">…и ещё @(group.MealGroupDishes.Count - 4).</p>
+                            <span>@ingredient</span>
                         }
+                    </div>
+                </div>
+            }
+        </aside>
+    </div>
+</section>
+
+@if (Model.UngroupedDishes.Any())
+{
+    <section id="ungrouped" class="ungrouped">
+        <header class="section-heading">
+            <div>
+                <p class="section-label">Без категории</p>
+                <h2>Блюда в ожидании своей коллекции</h2>
+            </div>
+            <a class="button ghost" asp-page="/Dishes/Index">Назначить группы</a>
+        </header>
+        <div class="dish-grid compact">
+            @foreach (var dish in Model.UngroupedDishes)
+            {
+                var ingredients = dish.DishProducts
+                    .Select(dp => dp.Product?.Name)
+                    .Where(name => !string.IsNullOrWhiteSpace(name))
+                    .Distinct()
+                    .ToList();
+                <article class="dish-card">
+                    <header>
+                        <div class="dish-title">
+                            <span class="dish-icon">✨</span>
+                            <h3>@dish.Name</h3>
+                        </div>
+                        <a class="ghost" asp-page="/Dishes/Index" asp-route-focus="@dish.Id">Открыть</a>
+                    </header>
+                    @if (!string.IsNullOrWhiteSpace(dish.Description))
+                    {
+                        <p>@dish.Description</p>
+                    }
+                    @if (ingredients.Count > 0)
+                    {
+                        <ul>
+                            @foreach (var ingredient in ingredients)
+                            {
+                                <li>@ingredient</li>
+                            }
+                        </ul>
                     }
                 </article>
             }
         </div>
     </section>
-
-    <section class="section-card">
-        <div class="section-header">
-            <div>
-                <h2 class="section-title">Быстрые идеи</h2>
-                <p class="section-subtitle">Готовые рецепты с минимальными усилиями.</p>
-            </div>
-            <a class="primary-button" asp-page="/Dishes/Index">Все блюда</a>
-        </div>
-
-        @if (Model.HighlightedDishes.Count == 0)
-        {
-            <div class="empty-state">
-                <p>Добавьте своё первое блюдо, чтобы увидеть его здесь.</p>
-            </div>
-        }
-        else
-        {
-            <div class="dish-list">
-                @foreach (var dish in Model.HighlightedDishes)
-                {
-                    <article class="dish-item">
-                        <div>
-                            <h3>@dish.Name</h3>
-                            <p class="muted">@dish.Description</p>
-                        </div>
-                        <div class="chip-group">
-                            @foreach (var link in dish.MealGroupDishes)
-                            {
-                                <span class="pill">@link.MealGroup.Name</span>
-                            }
-                        </div>
-                        <div class="dish-meta">
-                            @if (dish.PreparationMinutes.HasValue)
-                            {
-                                <span class="tag">⏱️ @dish.PreparationMinutes.Value мин</span>
-                            }
-                            <a class="secondary-button" asp-page="/Dishes/Index" asp-route-focus="@dish.Id">Открыть</a>
-                        </div>
-                    </article>
-                }
-            </div>
-        }
-    </section>
-
-    <section class="section-card">
-        <div class="section-header">
-            <div>
-                <h2 class="section-title">Продукты под рукой</h2>
-                <p class="section-subtitle">Список ингредиентов, которые всегда есть в доме.</p>
-            </div>
-            <a class="primary-button" asp-page="/Products/Index">Управлять</a>
-        </div>
-        @if (Model.PantryProducts.Count == 0)
-        {
-            <div class="empty-state">
-                <p>Заполните свою виртуальную кладовую и следите за запасами.</p>
-            </div>
-        }
-        else
-        {
-            <div class="chip-group">
-                @foreach (var product in Model.PantryProducts)
-                {
-                    <span class="pill">@product.Name</span>
-                }
-            </div>
-        }
-    </section>
-
-    @if (Model.UngroupedDishes.Count > 0)
-    {
-        <section class="section-card">
-            <div class="section-header">
-                <div>
-                    <h2 class="section-title">Без категории</h2>
-                    <p class="section-subtitle">Блюда, которые ещё не попали в коллекции.</p>
-                </div>
-            </div>
-            <div class="dish-list">
-                @foreach (var dish in Model.UngroupedDishes)
-                {
-                    <article class="dish-item">
-                        <div>
-                            <h3>@dish.Name</h3>
-                            <p class="muted">@dish.Description</p>
-                        </div>
-                        <div class="chip-group">
-                            @foreach (var ingredient in dish.DishProducts)
-                            {
-                                <span class="pill">@ingredient.Product.Name</span>
-                            }
-                        </div>
-                        <div class="dish-meta">
-                            <a class="secondary-button" asp-page="/Dishes/Index" asp-route-focus="@dish.Id">Назначить</a>
-                        </div>
-                    </article>
-                }
-            </div>
-        </section>
-    }
-</div>
+}

--- a/MealMate/Pages/Index.cshtml
+++ b/MealMate/Pages/Index.cshtml
@@ -20,8 +20,8 @@
             Добавляйте новые идеи, наводите порядок в запасах и держите всю кухонную магию под рукой.
         </p>
         <div class="hero-actions">
-            <a class="button primary" asp-page="/Dishes/Index">Собрать меню</a>
-            <a class="button ghost" asp-page="/MealGroups/Index">Коллекции блюд</a>
+            <a class="button primary" asp-page="/Menu/Index">Собрать меню</a>
+            <a class="button ghost" asp-page="/MealGroups/Index">Редактировать группы</a>
         </div>
         <div class="hero-stats">
             <div class="stat-card">
@@ -219,16 +219,14 @@
         </div>
         <aside class="actions">
             <div class="form-card">
-                <h3>Добавить блюдо</h3>
-                <p class="form-caption">Заполните карточку и пополните коллекцию свежими идеями.</p>
-                <a class="button primary" asp-page="/Dishes/Create">Новое блюдо</a>
-                <a class="button ghost" asp-page="/Dishes/Index">Все блюда</a>
+                <h3>Редактирование блюд</h3>
+                <p class="form-caption">Пополняйте коллекцию новыми идеями и обновляйте существующие рецепты.</p>
+                <a class="button primary" asp-page="/Dishes/Index">Открыть редактор блюд</a>
             </div>
             <div class="form-card">
-                <h3>Новая группа</h3>
-                <p class="form-caption">Соберите подборку для нового случая или настроения.</p>
-                <a class="button primary" asp-page="/MealGroups/Create">Создать группу</a>
-                <a class="button ghost" asp-page="/MealGroups/Index">Управление группами</a>
+                <h3>Редактирование групп</h3>
+                <p class="form-caption">Создавайте новые подборки и обновляйте оформление коллекций.</p>
+                <a class="button primary" asp-page="/MealGroups/Index">Открыть редактор групп</a>
             </div>
             @if (Model.HighlightedIngredients.Any())
             {

--- a/MealMate/Pages/Index.cshtml
+++ b/MealMate/Pages/Index.cshtml
@@ -1,4 +1,4 @@
-@page "{?focusGroup}"
+@page "{focusGroup:int?}"
 @model IndexModel
 @{
     ViewData["Title"] = "MealMate — планировщик питания";

--- a/MealMate/Pages/Index.cshtml.cs
+++ b/MealMate/Pages/Index.cshtml.cs
@@ -2,6 +2,7 @@ using MealMate.Data;
 using MealMate.Models;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+using System.Linq;
 
 namespace MealMate.Pages;
 
@@ -15,31 +16,47 @@ public class IndexModel : PageModel
     }
 
     public IList<MealGroup> MealGroups { get; private set; } = new List<MealGroup>();
-    public IList<Dish> HighlightedDishes { get; private set; } = new List<Dish>();
-    public IList<Product> PantryProducts { get; private set; } = new List<Product>();
+    public MealGroup? SelectedGroup { get; private set; }
     public IList<Dish> UngroupedDishes { get; private set; } = new List<Dish>();
+    public IList<string> HighlightedIngredients { get; private set; } = new List<string>();
+    public int TotalMealGroups { get; private set; }
+    public int TotalDishes { get; private set; }
+    public int TotalUniqueIngredients { get; private set; }
 
-    public async Task OnGetAsync()
+    public async Task OnGetAsync(int? focusGroup)
     {
         MealGroups = await _context.MealGroups
             .Include(g => g.MealGroupDishes)
                 .ThenInclude(mgd => mgd.Dish)
+                    .ThenInclude(d => d.DishProducts)
+                        .ThenInclude(dp => dp.Product)
             .OrderBy(g => g.Name)
             .ToListAsync();
 
-        HighlightedDishes = await _context.Dishes
-            .Include(d => d.MealGroupDishes)
-                .ThenInclude(mgd => mgd.MealGroup)
-            .Include(d => d.DishProducts)
-                .ThenInclude(dp => dp.Product)
-            .OrderBy(d => d.PreparationMinutes ?? int.MaxValue)
-            .ThenBy(d => d.Name)
-            .Take(6)
+        TotalMealGroups = MealGroups.Count;
+        TotalDishes = await _context.Dishes.CountAsync();
+        TotalUniqueIngredients = await _context.DishProducts
+            .Select(dp => dp.ProductId)
+            .Distinct()
+            .CountAsync();
+
+        HighlightedIngredients = await _context.DishProducts
+            .Include(dp => dp.Product)
+            .Where(dp => dp.Product != null)
+            .GroupBy(dp => dp.Product!.Name)
+            .Select(g => new { g.Key, Count = g.Count() })
+            .OrderByDescending(g => g.Count)
+            .ThenBy(g => g.Key)
+            .Take(12)
+            .Select(g => g.Key)
             .ToListAsync();
 
-        PantryProducts = await _context.Products
-            .OrderBy(p => p.Name)
-            .ToListAsync();
+        SelectedGroup = focusGroup.HasValue
+            ? MealGroups.FirstOrDefault(g => g.Id == focusGroup.Value)
+            : MealGroups.FirstOrDefault();
+
+        SelectedGroup ??= MealGroups.FirstOrDefault();
+
 
         UngroupedDishes = await _context.Dishes
             .Where(d => !d.MealGroupDishes.Any())

--- a/MealMate/Pages/MealGroups/Index.cshtml
+++ b/MealMate/Pages/MealGroups/Index.cshtml
@@ -88,7 +88,7 @@
                                             asp-route-id="@group.Id"
                                             formmethod="post"
                                             formnovalidate
-                                            onclick="return confirm('Удалить группу \"@group.Name\"?');"
+                                            onclick='return confirm("Удалить группу @group.Name?");'
                                             class="destructive-button">
                                         Удалить
                                     </button>

--- a/MealMate/Pages/MealGroups/Index.cshtml
+++ b/MealMate/Pages/MealGroups/Index.cshtml
@@ -1,15 +1,15 @@
 @page
 @model MealMate.Pages.MealGroups.IndexModel
 @{
-    ViewData["Title"] = "Группы блюд";
+    ViewData["Title"] = "Редактирование групп";
 }
 
 <div class="dashboard-grid">
     <section class="section-card">
         <div class="section-header">
             <div>
-                <h1 class="section-title">Создайте коллекцию блюд</h1>
-                <p class="section-subtitle">Группы помогают планировать меню для разных случаев.</p>
+                <h1 class="section-title">Редактор групп</h1>
+                <p class="section-subtitle">Настраивайте подборки для любых ситуаций, чтобы ускорить планирование меню.</p>
             </div>
         </div>
 
@@ -39,8 +39,8 @@
     <section class="section-card">
         <div class="section-header">
             <div>
-                <h2 class="section-title">Мои подборки</h2>
-                <p class="section-subtitle">Быстро редактируйте названия и описания, просматривайте блюда внутри.</p>
+                <h2 class="section-title">Текущие группы</h2>
+                <p class="section-subtitle">Изменяйте названия, описания и акценты, чтобы коллекции оставались актуальными.</p>
             </div>
         </div>
 

--- a/MealMate/Pages/Menu/Group.cshtml
+++ b/MealMate/Pages/Menu/Group.cshtml
@@ -1,0 +1,238 @@
+@page "{id:int}"
+@model MealMate.Pages.Menu.GroupModel
+@{
+    if (Model.Group is not null)
+    {
+        ViewData["Title"] = $"{Model.Group.Name} — подборка";
+    }
+    else
+    {
+        ViewData["Title"] = "Коллекция не найдена";
+    }
+}
+
+@if (Model.Group is null)
+{
+    <section class="menu-missing">
+        <h1>Группа не найдена</h1>
+        <p>Похоже, коллекция была удалена или ещё не создана.</p>
+        <a class="button primary" asp-page="/Menu/Index">Вернуться к списку групп</a>
+    </section>
+}
+else
+{
+    <section class="menu-group-hero">
+        <a class="button ghost" asp-page="/Menu/Index">← Все группы</a>
+        <div class="menu-group-hero__body">
+            <div class="menu-group-hero__badge" style="--accent-color: @(string.IsNullOrWhiteSpace(Model.Group.AccentColor) ? "#f97316" : Model.Group.AccentColor)"></div>
+            <div>
+                <p class="menu-label">Коллекция</p>
+                <h1>@Model.Group.Name</h1>
+                <p class="menu-subtitle">
+                    @(string.IsNullOrWhiteSpace(Model.Group.Description)
+                        ? "Добавьте описание, чтобы легче вспоминать настроение этой подборки."
+                        : Model.Group.Description)
+                </p>
+                <div class="menu-group-hero__meta">
+                    <span>@Model.Dishes.Count блюд</span>
+                    <span>@Model.UniqueIngredients.Count ингредиентов</span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    @if (Model.Dishes.Count == 0)
+    {
+        <section class="empty-state">
+            <h2>В этой коллекции пока нет блюд</h2>
+            <p>Добавьте блюда через страницу редактирования, чтобы увидеть их здесь.</p>
+            <a class="button primary" asp-page="/Dishes/Index" asp-route-group="@Model.Group.Id">Редактировать блюда</a>
+        </section>
+    }
+    else
+    {
+        <section class="menu-dishes">
+            <header class="menu-dishes__header">
+                <div>
+                    <h2>Блюда коллекции</h2>
+                    <p>Нажмите на карточку, чтобы раскрыть полное описание.</p>
+                </div>
+                <a class="button ghost" asp-page="/Dishes/Index" asp-route-focus="@Model.Dishes.First().Id">Редактировать блюда</a>
+            </header>
+
+            <div class="menu-dishes__grid" data-dish-grid>
+                @foreach (var dish in Model.Dishes)
+                {
+                    var accent = string.IsNullOrWhiteSpace(Model.Group.AccentColor) ? "#f97316" : Model.Group.AccentColor;
+                    var ingredients = dish.DishProducts
+                        .Select(dp => string.IsNullOrWhiteSpace(dp.Quantity)
+                            ? dp.Product?.Name
+                            : $"{dp.Product?.Name} ({dp.Quantity})")
+                        .Where(text => !string.IsNullOrWhiteSpace(text))
+                        .ToList();
+                    <article class="menu-dish-card" data-template-id="dish-template-@dish.Id" style="--accent-color: @accent">
+                        <div class="menu-dish-card__header">
+                            <h3>@dish.Name</h3>
+                            @if (dish.PreparationMinutes.HasValue)
+                            {
+                                <span class="menu-dish-card__time">@dish.PreparationMinutes.Value мин</span>
+                            }
+                        </div>
+                        <p class="menu-dish-card__description">
+                            @(string.IsNullOrWhiteSpace(dish.Description)
+                                ? "Краткое описание появится после редактирования блюда."
+                                : dish.Description)
+                        </p>
+                        @if (ingredients.Any())
+                        {
+                            <ul class="menu-dish-card__ingredients">
+                                @foreach (var ingredient in ingredients.Take(4))
+                                {
+                                    <li>@ingredient</li>
+                                }
+                                @if (ingredients.Count > 4)
+                                {
+                                    <li>и ещё @(ingredients.Count - 4)</li>
+                                }
+                            </ul>
+                        }
+                    </article>
+
+                    <template id="dish-template-@dish.Id">
+                        <div class="dish-modal__body">
+                            <header>
+                                <div>
+                                    <p class="menu-label">Блюдо</p>
+                                    <h2>@dish.Name</h2>
+                                </div>
+                                <button type="button" class="dish-modal__close" aria-label="Закрыть" data-close-modal>✕</button>
+                            </header>
+                            @if (!string.IsNullOrWhiteSpace(dish.ImageUrl))
+                            {
+                                <img src="@dish.ImageUrl" alt="Фото блюда @dish.Name" class="dish-modal__image" />
+                            }
+                            <div class="dish-modal__content">
+                                @if (!string.IsNullOrWhiteSpace(dish.Description))
+                                {
+                                    <p class="dish-modal__description">@dish.Description</p>
+                                }
+                                <div class="dish-modal__meta">
+                                    @if (dish.PreparationMinutes.HasValue)
+                                    {
+                                        <span class="tag">~@dish.PreparationMinutes.Value минут</span>
+                                    }
+                                    <a class="tag" asp-page="/Dishes/Index" asp-route-focus="@dish.Id">Редактировать</a>
+                                </div>
+                                <section class="dish-modal__section">
+                                    <h3>Ингредиенты</h3>
+                                    @if (!ingredients.Any())
+                                    {
+                                        <p class="dish-modal__muted">Ингредиенты ещё не указаны.</p>
+                                    }
+                                    else
+                                    {
+                                        <ul>
+                                            @foreach (var ingredient in ingredients)
+                                            {
+                                                <li>@ingredient</li>
+                                            }
+                                        </ul>
+                                    }
+                                </section>
+                                <section class="dish-modal__section">
+                                    <h3>Инструкция</h3>
+                                    @if (string.IsNullOrWhiteSpace(dish.Instructions))
+                                    {
+                                        <p class="dish-modal__muted">Добавьте инструкцию, чтобы быстрее готовить в следующий раз.</p>
+                                    }
+                                    else
+                                    {
+                                        <p>@dish.Instructions</p>
+                                    }
+                                </section>
+                            </div>
+                        </div>
+                    </template>
+                }
+            </div>
+        </section>
+    }
+
+    @if (Model.OtherGroups.Any())
+    {
+        <section class="menu-other-groups">
+            <h2>Другие коллекции</h2>
+            <div class="menu-other-groups__chips">
+                @foreach (var group in Model.OtherGroups)
+                {
+                    <a class="chip" asp-page="/Menu/Group" asp-route-id="@group.Id">@group.Name</a>
+                }
+            </div>
+        </section>
+    }
+
+    <div class="dish-modal" data-dish-modal hidden aria-hidden="true">
+        <div class="dish-modal__backdrop" data-close-modal></div>
+        <div class="dish-modal__container" role="dialog" aria-modal="true">
+        </div>
+    </div>
+}
+
+@section Scripts {
+    <script>
+        (() => {
+            const modalRoot = document.querySelector('[data-dish-modal]');
+            const modalContainer = modalRoot?.querySelector('.dish-modal__container');
+            const grid = document.querySelector('[data-dish-grid]');
+
+            if (!modalRoot || !modalContainer || !grid) {
+                return;
+            }
+
+            const openModal = (templateId) => {
+                const template = document.getElementById(templateId);
+                if (!template) {
+                    return;
+                }
+
+                modalContainer.innerHTML = '';
+                modalContainer.appendChild(template.content.cloneNode(true));
+                modalRoot.hidden = false;
+                modalRoot.setAttribute('aria-hidden', 'false');
+                document.body.classList.add('no-scroll');
+
+                modalContainer.querySelectorAll('[data-close-modal]').forEach(button => {
+                    button.addEventListener('click', closeModal, { once: true });
+                });
+            };
+
+            const closeModal = () => {
+                modalRoot.hidden = true;
+                modalRoot.setAttribute('aria-hidden', 'true');
+                modalContainer.innerHTML = '';
+                document.body.classList.remove('no-scroll');
+            };
+
+            modalRoot.addEventListener('click', (event) => {
+                if (event.target && event.target.matches('[data-close-modal], .dish-modal__backdrop')) {
+                    closeModal();
+                }
+            });
+
+            grid.querySelectorAll('.menu-dish-card').forEach(card => {
+                card.addEventListener('click', () => {
+                    const templateId = card.dataset.templateId;
+                    if (templateId) {
+                        openModal(templateId);
+                    }
+                });
+            });
+
+            document.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape' && !modalRoot.hidden) {
+                    closeModal();
+                }
+            });
+        })();
+    </script>
+}

--- a/MealMate/Pages/Menu/Group.cshtml.cs
+++ b/MealMate/Pages/Menu/Group.cshtml.cs
@@ -1,0 +1,65 @@
+using MealMate.Data;
+using MealMate.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+
+namespace MealMate.Pages.Menu;
+
+public class GroupModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+
+    public GroupModel(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public MealGroup? Group { get; private set; }
+    public IList<Dish> Dishes { get; private set; } = new List<Dish>();
+    public IList<string> UniqueIngredients { get; private set; } = new List<string>();
+    public IList<MealGroup> OtherGroups { get; private set; } = new List<MealGroup>();
+
+    public async Task<IActionResult> OnGetAsync(int id)
+    {
+        Group = await _context.MealGroups
+            .Include(g => g.MealGroupDishes)
+                .ThenInclude(link => link.Dish)
+                    .ThenInclude(d => d.DishProducts)
+                        .ThenInclude(dp => dp.Product)
+            .FirstOrDefaultAsync(g => g.Id == id);
+
+        if (Group is null)
+        {
+            await LoadOtherGroupsAsync(id);
+            return Page();
+        }
+
+        Dishes = Group.MealGroupDishes
+            .Select(link => link.Dish)
+            .OrderBy(dish => dish.Name)
+            .ToList();
+
+        UniqueIngredients = Dishes
+            .SelectMany(dish => dish.DishProducts)
+            .Select(dp => dp.Product?.Name)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Select(name => name!)
+            .Distinct()
+            .OrderBy(name => name)
+            .ToList();
+
+        await LoadOtherGroupsAsync(id);
+
+        return Page();
+    }
+
+    private async Task LoadOtherGroupsAsync(int currentId)
+    {
+        OtherGroups = await _context.MealGroups
+            .Where(group => group.Id != currentId)
+            .OrderBy(group => group.Name)
+            .ToListAsync();
+    }
+}

--- a/MealMate/Pages/Menu/Index.cshtml
+++ b/MealMate/Pages/Menu/Index.cshtml
@@ -1,0 +1,82 @@
+@page
+@model MealMate.Pages.Menu.IndexModel
+@using System.Linq
+@{
+    ViewData["Title"] = "Меню по коллекциям";
+}
+
+<section class="menu-hero">
+    <div>
+        <p class="menu-label">Подборки</p>
+        <h1>Выберите настроение — и мы покажем подходящие блюда</h1>
+        <p class="menu-subtitle">
+            Нажмите на коллекцию, чтобы посмотреть все блюда внутри. Здесь можно быстро пролистать варианты,
+            а для полного описания откройте карточку блюда на следующем шаге.
+        </p>
+    </div>
+</section>
+
+<section class="menu-groups">
+    <header class="menu-groups__header">
+        <div>
+            <h2>Текущие группы</h2>
+            <p>Всего @Model.TotalGroups групп и @Model.TotalDishes блюд в коллекциях.</p>
+        </div>
+        <a class="button ghost" asp-page="/MealGroups/Index">Редактировать группы</a>
+    </header>
+
+    @if (!Model.MealGroups.Any() && Model.UngroupedDishesCount == 0)
+    {
+        <div class="empty-state">
+            <h3>Пока нет коллекций</h3>
+            <p>Добавьте первую группу и блюда, чтобы начать планирование меню.</p>
+        </div>
+    }
+    else
+    {
+        <div class="menu-groups__grid">
+            @foreach (var group in Model.MealGroups)
+            {
+                var accent = string.IsNullOrWhiteSpace(group.AccentColor) ? "#f97316" : group.AccentColor;
+                var dishCount = group.MealGroupDishes.Count;
+                var ingredientNames = group.MealGroupDishes
+                    .SelectMany(link => link.Dish.DishProducts)
+                    .Select(dp => dp.Product?.Name)
+                    .Where(name => !string.IsNullOrWhiteSpace(name))
+                    .Distinct()
+                    .ToList();
+                var previewIngredients = ingredientNames.Take(3).ToList();
+                <article class="menu-group-card" style="--accent-color: @accent">
+                    <div class="menu-group-card__meta">
+                        <span class="menu-group-card__pill">@dishCount блюд</span>
+                        <span class="menu-group-card__pill">@ingredientNames.Count ингредиентов</span>
+                    </div>
+                    <h3>@group.Name</h3>
+                    <p>@(string.IsNullOrWhiteSpace(group.Description) ? "Добавьте описание группы, чтобы было проще выбирать." : group.Description)</p>
+                    @if (previewIngredients.Any())
+                    {
+                        <ul class="menu-group-card__ingredients">
+                            @foreach (var ingredient in previewIngredients)
+                            {
+                                <li>@ingredient</li>
+                            }
+                        </ul>
+                    }
+                    <a class="button primary" asp-page="Group" asp-route-id="@group.Id">Посмотреть блюда</a>
+                </article>
+            }
+
+            @if (Model.UngroupedDishesCount > 0)
+            {
+                <article class="menu-group-card is-neutral">
+                    <div class="menu-group-card__meta">
+                        <span class="menu-group-card__pill">@Model.UngroupedDishesCount блюд</span>
+                    </div>
+                    <h3>Без группы</h3>
+                    <p>Эти блюда ещё не попали в коллекции. Назначьте им место или создайте новую группу.</p>
+                    <a class="button ghost" asp-page="/Dishes/Index">Редактировать блюда</a>
+                </article>
+            }
+        </div>
+    }
+</section>

--- a/MealMate/Pages/Menu/Index.cshtml.cs
+++ b/MealMate/Pages/Menu/Index.cshtml.cs
@@ -1,0 +1,38 @@
+using MealMate.Data;
+using MealMate.Models;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+
+namespace MealMate.Pages.Menu;
+
+public class IndexModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+
+    public IndexModel(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public IList<MealGroup> MealGroups { get; private set; } = new List<MealGroup>();
+    public int TotalGroups { get; private set; }
+    public int TotalDishes { get; private set; }
+    public int UngroupedDishesCount { get; private set; }
+
+    public async Task OnGetAsync()
+    {
+        MealGroups = await _context.MealGroups
+            .Include(group => group.MealGroupDishes)
+                .ThenInclude(link => link.Dish)
+                    .ThenInclude(dish => dish.DishProducts)
+                        .ThenInclude(dp => dp.Product)
+            .OrderBy(group => group.Name)
+            .ToListAsync();
+
+        TotalGroups = MealGroups.Count;
+        TotalDishes = await _context.Dishes.CountAsync();
+        UngroupedDishesCount = await _context.Dishes
+            .CountAsync(dish => !dish.MealGroupDishes.Any());
+    }
+}

--- a/MealMate/Pages/Products/Index.cshtml
+++ b/MealMate/Pages/Products/Index.cshtml
@@ -73,8 +73,8 @@
                                 <button type="submit" class="secondary-button">Сохранить</button>
                             </div>
                         </form>
-                        <form method="post" asp-page-handler="Delete" asp-route-id="@product.Id" onsubmit="return confirm('Удалить продукт \"@product.Name\"?');">
-                            <button type="submit" class="destructive-button">Удалить</button>
+                        <form method="post" asp-page-handler="Delete" asp-route-id="@product.Id">
+                            <button type="submit" class="destructive-button" onclick="return confirm('Удалить продукт &quot;@product.Name&quot;?');">Удалить</button>
                         </form>
                     </div>
                 }

--- a/MealMate/Pages/Shared/_Layout.cshtml
+++ b/MealMate/Pages/Shared/_Layout.cshtml
@@ -26,8 +26,9 @@
         </button>
         <nav class="app-nav">
             <a class="nav-link" asp-page="/Index">Дашборд</a>
-            <a class="nav-link" asp-page="/Dishes/Index">Блюда</a>
-            <a class="nav-link" asp-page="/MealGroups/Index">Группы блюд</a>
+            <a class="nav-link" asp-page="/Menu/Index">Меню</a>
+            <a class="nav-link" asp-page="/Dishes/Index">Редактирование блюд</a>
+            <a class="nav-link" asp-page="/MealGroups/Index">Редактирование групп</a>
             <a class="nav-link" asp-page="/Products/Index">Продукты</a>
         </nav>
     </header>

--- a/MealMate/wwwroot/css/site.css
+++ b/MealMate/wwwroot/css/site.css
@@ -1113,3 +1113,456 @@ select:focus {
   margin-top: 4.8rem;
 }
 *** End of File
+
+/* -------- Меню и просмотр блюд -------- */
+.menu-hero {
+    background: linear-gradient(135deg, rgba(251, 191, 36, 0.16), rgba(59, 130, 246, 0.12));
+    border-radius: 32px;
+    padding: 64px clamp(24px, 6vw, 80px);
+    margin-bottom: 48px;
+    color: var(--text-primary);
+}
+
+.menu-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 12px;
+    border-radius: 999px;
+    background: rgba(59, 130, 246, 0.1);
+    color: var(--accent-primary, #2563EB);
+    font-weight: 600;
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 12px;
+}
+
+.menu-hero h1 {
+    font-size: clamp(2rem, 4vw, 3rem);
+    line-height: 1.1;
+    margin-bottom: 16px;
+}
+
+.menu-subtitle {
+    max-width: 760px;
+    color: var(--text-secondary);
+    font-size: 1.05rem;
+    line-height: 1.6;
+}
+
+.menu-groups {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+}
+
+.menu-groups__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 24px;
+}
+
+.menu-groups__header h2 {
+    font-size: clamp(1.6rem, 2.5vw, 2rem);
+}
+
+.menu-groups__header p {
+    color: var(--text-secondary);
+    margin-top: 8px;
+}
+
+.menu-groups__grid {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.menu-group-card {
+    position: relative;
+    border-radius: 24px;
+    padding: 28px;
+    background: #fff;
+    box-shadow: var(--shadow-lg);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.menu-group-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 2px;
+    background: linear-gradient(135deg, rgba(251, 191, 36, 0.6), var(--accent-color, #f97316));
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    opacity: 0.35;
+}
+
+.menu-group-card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-xl);
+}
+
+.menu-group-card h3 {
+    font-size: 1.4rem;
+}
+
+.menu-group-card p {
+    color: var(--text-secondary);
+    margin-bottom: 0;
+}
+
+.menu-group-card__meta {
+    display: flex;
+    gap: 12px;
+}
+
+.menu-group-card__pill {
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: rgba(59, 130, 246, 0.08);
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: var(--accent-color, #2563EB);
+}
+
+.menu-group-card__ingredients {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    padding-left: 0;
+    list-style: none;
+}
+
+.menu-group-card__ingredients li::before {
+    content: "•";
+    color: var(--accent-color, #2563EB);
+    margin-right: 6px;
+}
+
+.menu-group-card.is-neutral::before {
+    background: linear-gradient(135deg, rgba(148, 163, 184, 0.5), rgba(148, 163, 184, 0.2));
+}
+
+.menu-group-card.is-neutral .button {
+    align-self: flex-start;
+}
+
+.menu-group-hero {
+    margin-top: 24px;
+    margin-bottom: 40px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.menu-group-hero__body {
+    position: relative;
+    border-radius: 28px;
+    padding: clamp(24px, 6vw, 56px);
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(79, 70, 229, 0.16));
+    box-shadow: var(--shadow-lg);
+    display: grid;
+    gap: 32px;
+    grid-template-columns: minmax(0, 1fr);
+}
+
+.menu-group-hero__badge {
+    position: absolute;
+    width: clamp(12px, 3vw, 20px);
+    height: 100%;
+    left: 0;
+    top: 0;
+    border-radius: 28px 0 0 28px;
+    background: var(--accent-color, #f97316);
+    opacity: 0.45;
+}
+
+.menu-group-hero__meta {
+    display: flex;
+    gap: 16px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-top: 16px;
+}
+
+.menu-dishes {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.menu-dishes__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 24px;
+}
+
+.menu-dishes__grid {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.menu-dish-card {
+    position: relative;
+    border-radius: 20px;
+    padding: 24px;
+    background: #fff;
+    box-shadow: var(--shadow-md);
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.menu-dish-card::after {
+    content: "Открыть";
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--accent-color, #2563EB);
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.menu-dish-card:hover {
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-lg);
+}
+
+.menu-dish-card:hover::after {
+    opacity: 0.85;
+}
+
+.menu-dish-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.menu-dish-card__time {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--accent-color, #2563EB);
+    background: rgba(59, 130, 246, 0.1);
+    padding: 4px 10px;
+    border-radius: 999px;
+}
+
+.menu-dish-card__description {
+    color: var(--text-secondary);
+    line-height: 1.5;
+}
+
+.menu-dish-card__ingredients {
+    list-style: none;
+    padding-left: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.menu-dish-card__ingredients li::before {
+    content: "#";
+    color: var(--accent-color, #2563EB);
+    margin-right: 4px;
+}
+
+.menu-other-groups {
+    margin-top: 48px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.menu-other-groups__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.menu-missing {
+    padding: clamp(48px, 8vw, 80px);
+    border-radius: 32px;
+    background: linear-gradient(135deg, rgba(226, 232, 240, 0.6), rgba(203, 213, 225, 0.4));
+    text-align: center;
+    box-shadow: var(--shadow-lg);
+    display: grid;
+    gap: 16px;
+}
+
+.dish-modal {
+    position: fixed;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    background: rgba(15, 23, 42, 0.35);
+    padding: 24px;
+    z-index: 1000;
+}
+
+.dish-modal[hidden] {
+    display: none;
+}
+
+.dish-modal__backdrop {
+    position: absolute;
+    inset: 0;
+}
+
+.dish-modal__container {
+    position: relative;
+    max-width: min(680px, 100%);
+    width: 100%;
+    max-height: min(90vh, 840px);
+    overflow-y: auto;
+    border-radius: 24px;
+    background: #fff;
+    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
+    padding: clamp(24px, 4vw, 40px);
+}
+
+.dish-modal__body {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.dish-modal__body header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.dish-modal__close {
+    border: none;
+    background: rgba(148, 163, 184, 0.16);
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    cursor: pointer;
+    font-size: 1.2rem;
+    transition: background 0.2s ease;
+}
+
+.dish-modal__close:hover {
+    background: rgba(148, 163, 184, 0.3);
+}
+
+.dish-modal__image {
+    width: 100%;
+    border-radius: 20px;
+    object-fit: cover;
+    max-height: 320px;
+}
+
+.dish-modal__description {
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+.dish-modal__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.dish-modal__section {
+    display: grid;
+    gap: 12px;
+}
+
+.dish-modal__section h3 {
+    font-size: 1.1rem;
+}
+
+.dish-modal__section ul {
+    padding-left: 20px;
+    color: var(--text-secondary);
+    line-height: 1.5;
+}
+
+.dish-modal__muted {
+    color: var(--text-muted);
+}
+
+body.no-scroll {
+    overflow: hidden;
+}
+
+@media (max-width: 992px) {
+    .menu-groups__header,
+    .menu-dishes__header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .menu-group-card,
+    .menu-dish-card {
+        padding: 24px;
+    }
+
+    .dish-modal__container {
+        max-height: calc(100vh - 48px);
+    }
+}
+
+@media (max-width: 640px) {
+    .menu-hero {
+        padding: 36px 24px;
+    }
+
+    .menu-group-card,
+    .menu-dish-card {
+        padding: 20px;
+        border-radius: 18px;
+    }
+
+    .menu-group-card__meta {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .menu-dish-card::after {
+        display: none;
+    }
+
+    .menu-group-hero__body {
+        padding: 32px 24px 28px 32px;
+    }
+
+    .menu-group-hero__badge {
+        width: 12px;
+    }
+
+    .dish-modal__container {
+        padding: 24px 20px;
+    }
+
+    .dish-modal__body header {
+        flex-direction: column-reverse;
+        align-items: flex-start;
+    }
+
+    .dish-modal__close {
+        align-self: flex-end;
+    }
+}

--- a/MealMate/wwwroot/css/site.css
+++ b/MealMate/wwwroot/css/site.css
@@ -635,3 +635,481 @@ select:focus {
     text-align: left;
   }
 }
+
+/* Home page redesign */
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 3.2rem;
+  align-items: center;
+  background: var(--surface);
+  border-radius: 3.2rem;
+  padding: clamp(3.2rem, 5vw, 4.8rem);
+  box-shadow: var(--shadow);
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 10% 20%, rgba(59, 130, 246, 0.12), transparent 50%),
+              radial-gradient(circle at 80% 0%, rgba(236, 72, 153, 0.15), transparent 55%),
+              radial-gradient(circle at 50% 100%, rgba(14, 165, 233, 0.1), transparent 45%);
+  pointer-events: none;
+}
+
+.hero-text {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 1.6rem;
+}
+
+.hero-label {
+  margin: 0;
+  font-size: 1.4rem;
+  letter-spacing: 0.2rem;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 700;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(3.2rem, 4vw, 4.4rem);
+  line-height: 1.1;
+}
+
+.hero-description {
+  margin: 0;
+  font-size: 1.6rem;
+  line-height: 1.6;
+  color: var(--text-muted);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.2rem;
+  align-items: center;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  border-radius: 999px;
+  padding: 1.2rem 2.4rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button.primary {
+  background-image: var(--accent);
+  color: white;
+  border: none;
+  box-shadow: 0 15px 35px -20px rgba(244, 63, 94, 0.7);
+}
+
+.button.primary:hover,
+.button.primary:focus {
+  transform: translateY(-1px) scale(1.01);
+}
+
+.button.ghost {
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  color: var(--text);
+}
+
+.button.ghost:hover,
+.button.ghost:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px -22px rgba(15, 23, 42, 0.5);
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1.2rem;
+  margin-top: 0.8rem;
+}
+
+.stat-card {
+  display: grid;
+  gap: 0.4rem;
+  padding: 1.6rem;
+  border-radius: 1.6rem;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  backdrop-filter: blur(8px);
+  text-align: left;
+}
+
+.stat-number {
+  font-size: 2.4rem;
+  font-weight: 700;
+}
+
+.stat-label {
+  color: var(--text-muted);
+  font-size: 1.3rem;
+}
+
+.hero-visual {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.glass-card {
+  width: min(360px, 100%);
+  background: rgba(15, 23, 42, 0.75);
+  color: white;
+  border-radius: 2.4rem;
+  padding: 2.4rem;
+  box-shadow: 0 30px 65px -35px rgba(15, 23, 42, 0.75);
+  display: grid;
+  gap: 1.6rem;
+}
+
+.glass-card h3 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.glass-subtitle {
+  margin: 0;
+  font-size: 1.4rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.glass-dish {
+  display: grid;
+  gap: 1rem;
+}
+
+.glass-dish h4 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.glass-dish p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 1.4rem;
+}
+
+.glass-dish ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+  font-size: 1.4rem;
+}
+
+.glass-dish li {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.glass-dish li::before {
+  content: '•';
+  font-size: 1.2rem;
+  opacity: 0.65;
+}
+
+.glass-empty {
+  padding: 1.6rem;
+  border-radius: 1.6rem;
+  background: rgba(15, 23, 42, 0.35);
+  font-size: 1.4rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  margin-bottom: 2.4rem;
+}
+
+.section-heading > div > h2,
+.section-heading > div > p {
+  margin: 0;
+}
+
+.section-label {
+  font-size: 1.3rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.18rem;
+  color: var(--text-muted);
+}
+
+.section-description {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 1.5rem;
+  max-width: 680px;
+}
+
+.groups {
+  margin-top: 4.8rem;
+}
+
+.group-tabs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.6rem;
+}
+
+.group-tab {
+  display: grid;
+  gap: 1.6rem;
+  padding: 2rem;
+  border-radius: 2.4rem;
+  text-decoration: none;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 25px 45px -35px rgba(15, 23, 42, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.group-tab:hover,
+.group-tab:focus {
+  transform: translateY(-4px);
+  box-shadow: 0 35px 60px -45px rgba(15, 23, 42, 0.6);
+  border-color: rgba(15, 23, 42, 0.14);
+}
+
+.group-tab.active {
+  border-color: var(--accent-color, #f97316);
+  border-color: color-mix(in srgb, var(--accent-color, #f97316) 65%, white 35%);
+  box-shadow: 0 35px 65px -50px color-mix(in srgb, var(--accent-color, #f97316) 55%, rgba(15, 23, 42, 0.65) 45%);
+}
+
+.group-tab.ghost {
+  border-style: dashed;
+  background: rgba(255, 255, 255, 0.65);
+  align-content: space-between;
+}
+
+.group-info {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1.2rem;
+  align-items: start;
+}
+
+.group-icon {
+  width: 4.4rem;
+  height: 4.4rem;
+  border-radius: 1.2rem;
+  background: var(--accent-color, #f97316);
+  background: color-mix(in srgb, var(--accent-color, #f97316) 20%, white 80%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1.8rem;
+}
+
+.group-info h3 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.group-info p {
+  margin: 0.4rem 0 0;
+  color: var(--text-muted);
+  font-size: 1.4rem;
+}
+
+.group-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  font-size: 1.3rem;
+  color: var(--text-muted);
+}
+
+.planner {
+  margin-top: 4.8rem;
+}
+
+.planner-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 2.4rem;
+}
+
+@media (max-width: 1024px) {
+  .planner-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.dish-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.dish-grid.compact {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.dish-card {
+  display: grid;
+  gap: 1.4rem;
+  padding: 2rem;
+  border-radius: 2rem;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 20px 45px -38px rgba(15, 23, 42, 0.6);
+}
+
+.dish-card header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.2rem;
+}
+
+.dish-title {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.dish-icon {
+  width: 3.6rem;
+  height: 3.6rem;
+  border-radius: 1.2rem;
+  background: rgba(59, 130, 246, 0.12);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dish-card h3 {
+  margin: 0;
+  font-size: 1.7rem;
+}
+
+.dish-card p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 1.4rem;
+}
+
+.dish-card ul {
+  margin: 0;
+  padding-left: 1.6rem;
+  color: var(--text);
+  display: grid;
+  gap: 0.4rem;
+  font-size: 1.35rem;
+}
+
+.dish-card footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.recipe-link {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.recipe-link:hover,
+.recipe-link:focus {
+  text-decoration: underline;
+}
+
+.empty-state {
+  padding: 3.2rem;
+  text-align: center;
+  border-radius: 2.4rem;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 20px 45px -38px rgba(15, 23, 42, 0.5);
+  display: grid;
+  gap: 1rem;
+}
+
+.actions {
+  display: grid;
+  gap: 2rem;
+}
+
+.form-card {
+  padding: 2.4rem;
+  border-radius: 2.4rem;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 25px 50px -40px rgba(15, 23, 42, 0.55);
+  display: grid;
+  gap: 1.2rem;
+}
+
+.form-card h3 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.form-caption {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 1.4rem;
+}
+
+.ingredient-cloud {
+  padding: 2.4rem;
+  border-radius: 2.4rem;
+  background: rgba(15, 23, 42, 0.85);
+  color: white;
+  display: grid;
+  gap: 1.4rem;
+  box-shadow: 0 30px 60px -45px rgba(15, 23, 42, 0.7);
+}
+
+.ingredient-cloud h3 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.chips span {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  color: white;
+  font-size: 1.3rem;
+}
+
+.ungrouped {
+  margin-top: 4.8rem;
+}
+*** End of File

--- a/MealMate/wwwroot/css/site.css
+++ b/MealMate/wwwroot/css/site.css
@@ -1202,6 +1202,7 @@ select:focus {
     -webkit-mask-composite: xor;
     mask-composite: exclude;
     opacity: 0.35;
+    pointer-events: none;
 }
 
 .menu-group-card:hover {


### PR DESCRIPTION
## Summary
- replace the landing page markup with a hero, group navigation, and planner sections styled after the original UI concept
- enrich the index page model with menu statistics, highlighted ingredients, and selected group handling
- extend the site stylesheet with new layouts and components supporting the refreshed design

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68de3444c4148330bcfd63d2924c74d7