### PR TITLE
Redesign dish cards with inline editing

### DIFF
--- a/MealMate/Pages/Dishes/Index.cshtml
+++ b/MealMate/Pages/Dishes/Index.cshtml
@@ -179,7 +179,7 @@
                             }
                         </div>
 
-                        <form method="post" asp-page-handler="Update" asp-route-id="@dish.Id" class="dish-edit-form @(isEditing ? "is-visible" : string.Empty)" id="dish-edit-@dish.Id" @(isEditing ? string.Empty : "hidden")>
+                        <form method="post" asp-page-handler="Update" asp-route-id="@dish.Id" class="dish-edit-form@(isEditing ? " is-visible" : string.Empty)" id="dish-edit-@dish.Id" aria-hidden="@(isEditing ? "false" : "true")">
                             <div class="form-row">
                                 <label for="edit-name-@dish.Id">Название</label>
                                 <input id="edit-name-@dish.Id" name="EditedDish.Name" value="@(isEditing ? Model.EditedDish.Name : dish.Name)" required maxlength="100" />
@@ -263,14 +263,9 @@
                 const form = card.querySelector('.dish-edit-form');
                 if (!form) return;
 
-                const willOpen = form.hasAttribute('hidden');
-                if (willOpen) {
-                    form.removeAttribute('hidden');
-                    form.classList.add('is-visible');
-                } else {
-                    form.setAttribute('hidden', 'hidden');
-                    form.classList.remove('is-visible');
-                }
+                const willOpen = !form.classList.contains('is-visible');
+                form.classList.toggle('is-visible', willOpen);
+                form.setAttribute('aria-hidden', willOpen ? 'false' : 'true');
 
                 const relatedButtons = card.querySelectorAll('[data-action="toggle-edit"]');
                 relatedButtons.forEach((btn) => {

--- a/MealMate/Pages/Dishes/Index.cshtml
+++ b/MealMate/Pages/Dishes/Index.cshtml
@@ -97,53 +97,146 @@
             <div class="dish-list">
                 @foreach (var dish in Model.Dishes)
                 {
-                    var focusClass = Model.FocusId == dish.Id ? "is-focus" : string.Empty;
-                    <article id="dish-@dish.Id" class="dish-item @focusClass">
-                        <div class="dish-details">
-                            <h3>@dish.Name</h3>
-                            <p class="muted">@dish.Description</p>
+                    var isHighlighted = Model.FocusId == dish.Id;
+                    var isEditing = Model.EditingId == dish.Id;
+                    var selectedProducts = isEditing ? Model.EditedDish.SelectedProductIds : dish.DishProducts.Select(dp => dp.ProductId).ToList();
+                    var selectedGroups = isEditing ? Model.EditedDish.SelectedMealGroupIds : dish.MealGroupDishes.Select(mg => mg.MealGroupId).ToList();
+                    var cardClasses = $"dish-card{(isHighlighted ? " is-focus" : string.Empty)}";
+                    <article id="dish-@dish.Id" class="@cardClasses" data-dish-id="@dish.Id">
+                        <header class="dish-card__header">
+                            <div class="dish-card__title">
+                                <h3>@dish.Name</h3>
+                                @if (dish.PreparationMinutes.HasValue)
+                                {
+                                    <span class="dish-card__meta" title="Время приготовления">
+                                        ⏱️ @dish.PreparationMinutes.Value мин
+                                    </span>
+                                }
+                            </div>
+                            <div class="dish-card__actions">
+                                <button type="button" class="ghost-button" data-action="toggle-edit" aria-expanded="@(isEditing ? "true" : "false")" aria-controls="dish-edit-@dish.Id">
+                                    @(isEditing ? "Скрыть" : "Редактировать")
+                                </button>
+                                <form method="post" asp-page-handler="Delete" asp-route-id="@dish.Id" onsubmit='return confirm("Удалить блюдо @dish.Name?");'>
+                                    <button type="submit" class="destructive-button">Удалить</button>
+                                </form>
+                            </div>
+                        </header>
+
+                        <div class="dish-card__body">
+                            @if (!string.IsNullOrWhiteSpace(dish.Description))
+                            {
+                                <p class="dish-card__description">@dish.Description</p>
+                            }
+
+                            <div class="dish-card__tags">
+                                <div>
+                                    <strong>Продукты</strong>
+                                    <div class="chip-group">
+                                        @if (!dish.DishProducts.Any())
+                                        {
+                                            <span class="pill">Не указаны</span>
+                                        }
+                                        else
+                                        {
+                                            @foreach (var ingredient in dish.DishProducts)
+                                            {
+                                                <span class="pill">
+                                                    @ingredient.Product.Name
+                                                    @if (!string.IsNullOrWhiteSpace(ingredient.Quantity))
+                                                    {
+                                                        <text>(@ingredient.Quantity)</text>
+                                                    }
+                                                </span>
+                                            }
+                                        }
+                                    </div>
+                                </div>
+                                <div>
+                                    <strong>Группы</strong>
+                                    <div class="chip-group">
+                                        @if (!dish.MealGroupDishes.Any())
+                                        {
+                                            <span class="pill">Не назначено</span>
+                                        }
+                                        else
+                                        {
+                                            @foreach (var link in dish.MealGroupDishes)
+                                            {
+                                                <span class="pill">@link.MealGroup.Name</span>
+                                            }
+                                        }
+                                    </div>
+                                </div>
+                            </div>
+
                             @if (!string.IsNullOrWhiteSpace(dish.Instructions))
                             {
-                                <details>
+                                <details class="dish-card__instructions" @(isEditing ? "open" : string.Empty)>
                                     <summary>Инструкция</summary>
                                     <p>@dish.Instructions</p>
                                 </details>
                             }
                         </div>
-                        <div class="chip-column">
-                            <strong>Продукты:</strong>
-                            @if (dish.DishProducts.Count == 0)
-                            {
-                                <span class="pill">Не указаны</span>
-                            }
-                            else
-                            {
-                                @foreach (var ingredient in dish.DishProducts)
-                                {
-                                    <span class="pill">@ingredient.Product.Name @if (!string.IsNullOrEmpty(ingredient.Quantity)){<text>(@ingredient.Quantity)</text>}</span>
-                                }
-                            }
-                        </div>
-                        <div class="chip-column">
-                            <strong>Группы:</strong>
-                            @if (dish.MealGroupDishes.Count == 0)
-                            {
-                                <span class="pill">Не назначено</span>
-                            }
-                            else
-                            {
-                                @foreach (var link in dish.MealGroupDishes)
-                                {
-                                    <span class="pill">@link.MealGroup.Name</span>
-                                }
-                            }
-                        </div>
-                    <form method="post" asp-page-handler="Delete" asp-route-id="@dish.Id" class="dish-actions" onsubmit='return confirm("Удалить блюдо @dish.Name?");'>
-                                <form method="post" asp-page-handler="Delete" asp-route-id="@dish.Id" class="dish-actions" onsubmit='return confirm("Удалить блюдо @dish.Name?");'>
-                                    <button type="submit" class="destructive-button">Удалить</button>
-                                </form>
-                            <button type="submit" class="destructive-button">Удалить</button>
-                    </form>
+
+                        <form method="post" asp-page-handler="Update" asp-route-id="@dish.Id" class="dish-edit-form @(isEditing ? "is-visible" : string.Empty)" id="dish-edit-@dish.Id" @(isEditing ? string.Empty : "hidden")>
+                            <div class="form-row">
+                                <label for="edit-name-@dish.Id">Название</label>
+                                <input id="edit-name-@dish.Id" name="EditedDish.Name" value="@(isEditing ? Model.EditedDish.Name : dish.Name)" required maxlength="100" />
+                            </div>
+                            <div class="form-row">
+                                <label for="edit-description-@dish.Id">Краткое описание</label>
+                                <input id="edit-description-@dish.Id" name="EditedDish.Description" value="@(isEditing ? Model.EditedDish.Description : dish.Description)" maxlength="300" />
+                            </div>
+                            <div class="form-row">
+                                <label for="edit-instructions-@dish.Id">Инструкция приготовления</label>
+                                <textarea id="edit-instructions-@dish.Id" name="EditedDish.Instructions" rows="4" maxlength="2000">@(isEditing ? Model.EditedDish.Instructions : dish.Instructions)</textarea>
+                            </div>
+                            <div class="form-row">
+                                <div class="dual-grid">
+                                    <div>
+                                        <label for="edit-prep-@dish.Id">Время, мин</label>
+                                        <input id="edit-prep-@dish.Id" name="EditedDish.PreparationMinutes" type="number" min="1" max="360" value="@(isEditing ? Model.EditedDish.PreparationMinutes : dish.PreparationMinutes)" />
+                                    </div>
+                                    <div>
+                                        <label for="edit-image-@dish.Id">Ссылка на изображение</label>
+                                        <input id="edit-image-@dish.Id" name="EditedDish.ImageUrl" value="@(isEditing ? Model.EditedDish.ImageUrl : dish.ImageUrl)" maxlength="200" />
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <span class="form-label">@Html.DisplayNameFor(m => m.NewDish.SelectedProductIds)</span>
+                                <div class="chip-group">
+                                    @foreach (var option in Model.ProductOptions)
+                                    {
+                                        var productId = int.Parse(option.Value!);
+                                        var isChecked = selectedProducts.Contains(productId);
+                                        <label class="checkbox-chip">
+                                            <input type="checkbox" name="EditedDish.SelectedProductIds" value="@option.Value" @(isChecked ? "checked" : string.Empty) />
+                                            <span>@option.Text</span>
+                                        </label>
+                                    }
+                                </div>
+                            </div>
+                            <div class="form-row">
+                                <span class="form-label">@Html.DisplayNameFor(m => m.NewDish.SelectedMealGroupIds)</span>
+                                <div class="chip-group">
+                                    @foreach (var option in Model.MealGroupOptions)
+                                    {
+                                        var groupId = int.Parse(option.Value!);
+                                        var isChecked = selectedGroups.Contains(groupId);
+                                        <label class="checkbox-chip">
+                                            <input type="checkbox" name="EditedDish.SelectedMealGroupIds" value="@option.Value" @(isChecked ? "checked" : string.Empty) />
+                                            <span>@option.Text</span>
+                                        </label>
+                                    }
+                                </div>
+                            </div>
+                            <div class="dish-edit-actions">
+                                <button type="submit" class="primary-button">Сохранить изменения</button>
+                                <button type="button" class="ghost-button" data-action="toggle-edit" data-close="true">Отменить</button>
+                            </div>
+                        </form>
                     </article>
                 }
             </div>
@@ -162,4 +255,34 @@
             }
         </script>
     }
+    <script>
+        document.querySelectorAll('[data-action="toggle-edit"]').forEach((button) => {
+            button.addEventListener('click', () => {
+                const card = button.closest('.dish-card');
+                if (!card) return;
+                const form = card.querySelector('.dish-edit-form');
+                if (!form) return;
+
+                const willOpen = form.hasAttribute('hidden');
+                if (willOpen) {
+                    form.removeAttribute('hidden');
+                    form.classList.add('is-visible');
+                } else {
+                    form.setAttribute('hidden', 'hidden');
+                    form.classList.remove('is-visible');
+                }
+
+                const relatedButtons = card.querySelectorAll('[data-action="toggle-edit"]');
+                relatedButtons.forEach((btn) => {
+                    const expanded = willOpen ? 'true' : 'false';
+                    btn.setAttribute('aria-expanded', expanded);
+                    if (expanded === 'true') {
+                        btn.textContent = btn.dataset.close ? 'Отменить' : 'Скрыть';
+                    } else {
+                        btn.textContent = btn.dataset.close ? 'Отменить' : 'Редактировать';
+                    }
+                });
+            });
+        });
+    </script>
 }

--- a/MealMate/Pages/Dishes/Index.cshtml
+++ b/MealMate/Pages/Dishes/Index.cshtml
@@ -46,16 +46,37 @@
             </div>
             <div class="form-row">
                 <span class="form-label">@Html.DisplayNameFor(m => m.NewDish.SelectedProductIds)</span>
-                <div class="chip-group">
-                    @foreach (var option in Model.ProductOptions)
-                    {
-                        var productId = int.Parse(option.Value!);
-                        var isChecked = Model.NewDish.SelectedProductIds.Contains(productId);
-                        <label class="checkbox-chip">
-                            <input type="checkbox" name="NewDish.SelectedProductIds" value="@option.Value" @(isChecked ? "checked" : string.Empty) />
-                            <span>@option.Text</span>
-                        </label>
-                    }
+                <div class="multiselect" data-multiselect data-name="NewDish.SelectedProductIds">
+                    <div class="multiselect__control">
+                        <div class="multiselect__chips" data-selected-list data-placeholder="Выбранные продукты появятся здесь">
+                            @foreach (var productId in Model.NewDish.SelectedProductIds)
+                            {
+                                var selectedOption = Model.ProductOptions.FirstOrDefault(option => option.Value == productId.ToString());
+                                if (selectedOption is not null)
+                                {
+                                    <button type="button" class="multiselect__chip" data-chip data-value="@selectedOption.Value" title="Удалить продукт">@selectedOption.Text</button>
+                                }
+                            }
+                        </div>
+                        <input type="text" class="multiselect__search" data-search-input placeholder="Начните вводить название продукта" aria-label="Добавить продукт" autocomplete="off" />
+                    </div>
+                    <div class="multiselect__dropdown" data-dropdown>
+                        <ul class="multiselect__options">
+                            @foreach (var option in Model.ProductOptions)
+                            {
+                                var productId = int.Parse(option.Value!);
+                                var isSelected = Model.NewDish.SelectedProductIds.Contains(productId);
+                                <li class="multiselect__option@(isSelected ? " is-hidden" : string.Empty)" data-option data-value="@option.Value" data-label="@option.Text">@option.Text</li>
+                            }
+                        </ul>
+                        <div class="multiselect__empty" data-empty-state hidden>Ничего не найдено</div>
+                    </div>
+                    <div class="multiselect__hidden" data-hidden-inputs>
+                        @foreach (var productId in Model.NewDish.SelectedProductIds)
+                        {
+                            <input type="hidden" name="NewDish.SelectedProductIds" value="@productId" data-hidden-value="@productId" />
+                        }
+                    </div>
                 </div>
             </div>
             <div class="form-row">
@@ -208,16 +229,37 @@
                             </div>
                             <div class="form-row">
                                 <span class="form-label">@Html.DisplayNameFor(m => m.NewDish.SelectedProductIds)</span>
-                                <div class="chip-group">
-                                    @foreach (var option in Model.ProductOptions)
-                                    {
-                                        var productId = int.Parse(option.Value!);
-                                        var isChecked = selectedProducts.Contains(productId);
-                                        <label class="checkbox-chip">
-                                            <input type="checkbox" name="EditedDish.SelectedProductIds" value="@option.Value" @(isChecked ? "checked" : string.Empty) />
-                                            <span>@option.Text</span>
-                                        </label>
-                                    }
+                                <div class="multiselect" data-multiselect data-name="EditedDish.SelectedProductIds">
+                                    <div class="multiselect__control">
+                                        <div class="multiselect__chips" data-selected-list data-placeholder="Выбранные продукты появятся здесь">
+                                            @foreach (var productId in selectedProducts)
+                                            {
+                                                var selectedOption = Model.ProductOptions.FirstOrDefault(option => option.Value == productId.ToString());
+                                                if (selectedOption is not null)
+                                                {
+                                                    <button type="button" class="multiselect__chip" data-chip data-value="@selectedOption.Value" title="Удалить продукт">@selectedOption.Text</button>
+                                                }
+                                            }
+                                        </div>
+                                        <input type="text" class="multiselect__search" data-search-input placeholder="Начните вводить название продукта" aria-label="Добавить продукт" autocomplete="off" />
+                                    </div>
+                                    <div class="multiselect__dropdown" data-dropdown>
+                                        <ul class="multiselect__options">
+                                            @foreach (var option in Model.ProductOptions)
+                                            {
+                                                var productId = int.Parse(option.Value!);
+                                                var isSelected = selectedProducts.Contains(productId);
+                                                <li class="multiselect__option@(isSelected ? " is-hidden" : string.Empty)" data-option data-value="@option.Value" data-label="@option.Text">@option.Text</li>
+                                            }
+                                        </ul>
+                                        <div class="multiselect__empty" data-empty-state hidden>Ничего не найдено</div>
+                                    </div>
+                                    <div class="multiselect__hidden" data-hidden-inputs>
+                                        @foreach (var productId in selectedProducts)
+                                        {
+                                            <input type="hidden" name="EditedDish.SelectedProductIds" value="@productId" data-hidden-value="@productId" />
+                                        }
+                                    </div>
                                 </div>
                             </div>
                             <div class="form-row">
@@ -281,5 +323,286 @@
                 });
             });
         });
+
+        (function () {
+            const components = Array.from(document.querySelectorAll('[data-multiselect]'));
+            if (!components.length) {
+                return;
+            }
+
+            const closeOthers = (current) => {
+                components.forEach((component) => {
+                    if (component !== current) {
+                        component.classList.remove('is-open');
+                    }
+                });
+            };
+
+            document.addEventListener('click', (event) => {
+                components.forEach((component) => {
+                    if (!component.contains(event.target)) {
+                        component.classList.remove('is-open');
+                    }
+                });
+            });
+
+            components.forEach((component) => {
+                const fieldName = component.dataset.name;
+                const searchInput = component.querySelector('[data-search-input]');
+                const options = Array.from(component.querySelectorAll('[data-option]'));
+                const selectedList = component.querySelector('[data-selected-list]');
+                const hiddenContainer = component.querySelector('[data-hidden-inputs]');
+                const emptyState = component.querySelector('[data-empty-state]');
+
+                if (!fieldName || !searchInput || !selectedList || !hiddenContainer) {
+                    return;
+                }
+
+                const valueSet = new Set(Array.from(hiddenContainer.querySelectorAll('input[name="' + fieldName + '"]')).map((input) => input.value));
+                let activeIndex = -1;
+
+                const getVisibleOptions = () => options.filter((option) => !option.classList.contains('is-hidden'));
+
+                const updateActiveOption = () => {
+                    options.forEach((option) => option.classList.remove('is-active'));
+                    const visible = getVisibleOptions();
+                    if (activeIndex >= 0 && activeIndex < visible.length) {
+                        const activeOption = visible[activeIndex];
+                        activeOption.classList.add('is-active');
+                        activeOption.scrollIntoView({ block: 'nearest' });
+                    }
+                };
+
+                const updateEmptyState = () => {
+                    if (!emptyState) {
+                        return;
+                    }
+                    const hasVisible = getVisibleOptions().length > 0;
+                    emptyState.hidden = hasVisible;
+                };
+
+                const filterOptions = () => {
+                    const term = searchInput.value.trim().toLowerCase();
+                    options.forEach((option) => {
+                        const value = option.dataset.value;
+                        if (!value || valueSet.has(value)) {
+                            option.classList.add('is-hidden');
+                            return;
+                        }
+
+                        if (!term) {
+                            option.classList.remove('is-hidden');
+                            return;
+                        }
+
+                        const label = option.dataset.label?.toLowerCase() ?? '';
+                        option.classList.toggle('is-hidden', !label.includes(term));
+                    });
+
+                    const visible = getVisibleOptions();
+                    activeIndex = visible.length ? 0 : -1;
+                    updateActiveOption();
+                    updateEmptyState();
+                };
+
+                const openDropdown = () => {
+                    component.classList.add('is-open');
+                    closeOthers(component);
+                    filterOptions();
+                };
+
+                const closeDropdown = () => {
+                    component.classList.remove('is-open');
+                    activeIndex = -1;
+                    updateActiveOption();
+                };
+
+                const removeValue = (value) => {
+                    if (!valueSet.has(value)) {
+                        return;
+                    }
+
+                    valueSet.delete(value);
+
+                    hiddenContainer.querySelectorAll('[data-hidden-value]').forEach((input) => {
+                        if (input.getAttribute('data-hidden-value') === value) {
+                            input.remove();
+                        }
+                    });
+
+                    selectedList.querySelectorAll('[data-chip]').forEach((chip) => {
+                        if (chip.getAttribute('data-value') === value) {
+                            chip.remove();
+                        }
+                    });
+
+                    const option = options.find((item) => item.dataset.value === value);
+                    if (option) {
+                        option.classList.remove('is-hidden');
+                    }
+
+                    filterOptions();
+                };
+
+                const addValue = (value, label) => {
+                    if (!value || valueSet.has(value)) {
+                        return;
+                    }
+
+                    valueSet.add(value);
+
+                    const hiddenInput = document.createElement('input');
+                    hiddenInput.type = 'hidden';
+                    hiddenInput.name = fieldName;
+                    hiddenInput.value = value;
+                    hiddenInput.setAttribute('data-hidden-value', value);
+                    hiddenContainer.appendChild(hiddenInput);
+
+                    const chip = document.createElement('button');
+                    chip.type = 'button';
+                    chip.className = 'multiselect__chip';
+                    chip.setAttribute('data-chip', '');
+                    chip.setAttribute('data-value', value);
+                    chip.title = 'Удалить продукт';
+                    chip.textContent = label;
+                    chip.addEventListener('click', (event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        removeValue(value);
+                        searchInput.focus();
+                    });
+                    selectedList.appendChild(chip);
+
+                    const option = options.find((item) => item.dataset.value === value);
+                    if (option) {
+                        option.classList.add('is-hidden');
+                    }
+
+                    searchInput.value = '';
+                    filterOptions();
+                    openDropdown();
+                };
+
+                selectedList.querySelectorAll('[data-chip]').forEach((chip) => {
+                    const value = chip.getAttribute('data-value');
+                    if (!value) {
+                        return;
+                    }
+
+                    valueSet.add(value);
+
+                    chip.addEventListener('click', (event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        removeValue(value);
+                        searchInput.focus();
+                    });
+                });
+
+                filterOptions();
+
+                options.forEach((option) => {
+                    option.addEventListener('click', (event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        const value = option.dataset.value;
+                        if (!value) {
+                            return;
+                        }
+
+                        addValue(value, option.dataset.label ?? option.textContent ?? value);
+                    });
+                });
+
+                component.addEventListener('mousedown', (event) => {
+                    if (event.target instanceof Element) {
+                        if (event.target.closest('[data-option]') || event.target.closest('[data-chip]')) {
+                            return;
+                        }
+                    }
+
+                    event.preventDefault();
+                    searchInput.focus();
+                    openDropdown();
+                });
+
+                searchInput.addEventListener('focus', () => {
+                    openDropdown();
+                });
+
+                searchInput.addEventListener('input', () => {
+                    filterOptions();
+                });
+
+                searchInput.addEventListener('keydown', (event) => {
+                    if (event.key === 'Backspace' && !searchInput.value) {
+                        const lastChip = selectedList.lastElementChild;
+                        if (lastChip instanceof HTMLElement) {
+                            const value = lastChip.getAttribute('data-value');
+                            if (value) {
+                                event.preventDefault();
+                                removeValue(value);
+                            }
+                        }
+                        return;
+                    }
+
+                    if (event.key === 'Enter') {
+                        event.preventDefault();
+                        const visible = getVisibleOptions();
+                        if (!visible.length) {
+                            return;
+                        }
+
+                        const option = activeIndex >= 0 ? visible[activeIndex] : visible[0];
+                        const value = option.dataset.value;
+                        if (value) {
+                            addValue(value, option.dataset.label ?? option.textContent ?? value);
+                        }
+                        return;
+                    }
+
+                    if (event.key === 'ArrowDown') {
+                        event.preventDefault();
+                        const visible = getVisibleOptions();
+                        if (!visible.length) {
+                            return;
+                        }
+
+                        if (activeIndex < visible.length - 1) {
+                            activeIndex += 1;
+                        } else {
+                            activeIndex = 0;
+                        }
+
+                        updateActiveOption();
+                        return;
+                    }
+
+                    if (event.key === 'ArrowUp') {
+                        event.preventDefault();
+                        const visible = getVisibleOptions();
+                        if (!visible.length) {
+                            return;
+                        }
+
+                        if (activeIndex <= 0) {
+                            activeIndex = visible.length - 1;
+                        } else {
+                            activeIndex -= 1;
+                        }
+
+                        updateActiveOption();
+                        return;
+                    }
+
+                    if (event.key === 'Escape') {
+                        event.preventDefault();
+                        closeDropdown();
+                        searchInput.blur();
+                    }
+                });
+            });
+        })();
     </script>
 }

--- a/MealMate/Pages/Dishes/Index.cshtml
+++ b/MealMate/Pages/Dishes/Index.cshtml
@@ -180,9 +180,11 @@
                         </div>
 
                         <form method="post" asp-page-handler="Update" asp-route-id="@dish.Id" class="dish-edit-form@(isEditing ? " is-visible" : string.Empty)" id="dish-edit-@dish.Id" aria-hidden="@(isEditing ? "false" : "true")">
+                            <div asp-validation-summary="ModelOnly" class="validation-errors"></div>
                             <div class="form-row">
                                 <label for="edit-name-@dish.Id">Название</label>
                                 <input id="edit-name-@dish.Id" name="EditedDish.Name" value="@(isEditing ? Model.EditedDish.Name : dish.Name)" required maxlength="100" />
+                                <span class="text-danger" data-valmsg-for="EditedDish.Name" data-valmsg-replace="true"></span>
                             </div>
                             <div class="form-row">
                                 <label for="edit-description-@dish.Id">Краткое описание</label>

--- a/MealMate/Pages/Dishes/Index.cshtml.cs
+++ b/MealMate/Pages/Dishes/Index.cshtml.cs
@@ -1,7 +1,10 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using MealMate.Data;
 using MealMate.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
@@ -21,8 +24,11 @@ public class IndexModel : PageModel
     public IList<SelectListItem> ProductOptions { get; private set; } = new List<SelectListItem>();
     public IList<SelectListItem> MealGroupOptions { get; private set; } = new List<SelectListItem>();
     public int? FocusId { get; private set; }
+    public int? EditingId { get; private set; }
     [BindProperty]
     public DishInputModel NewDish { get; set; } = new();
+    [BindProperty]
+    public DishInputModel EditedDish { get; set; } = new();
 
     public async Task OnGetAsync(int? focus)
     {
@@ -32,6 +38,9 @@ public class IndexModel : PageModel
 
     public async Task<IActionResult> OnPostAddAsync()
     {
+        ModelState.ClearValidationState(nameof(EditedDish));
+        ModelState.MarkFieldSkipped(nameof(EditedDish));
+
         if (!ModelState.IsValid)
         {
             await LoadAsync();
@@ -74,6 +83,81 @@ public class IndexModel : PageModel
         _context.Dishes.Remove(dish);
         await _context.SaveChangesAsync();
         return RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostUpdateAsync(int id)
+    {
+        FocusId = id;
+        EditingId = id;
+
+        ModelState.ClearValidationState(nameof(NewDish));
+        ModelState.MarkFieldSkipped(nameof(NewDish));
+
+        if (!TryValidateModel(EditedDish, nameof(EditedDish)))
+        {
+            await LoadAsync();
+            FocusId = id;
+            EditingId = id;
+            return Page();
+        }
+
+        EditedDish.SelectedProductIds ??= new List<int>();
+        EditedDish.SelectedMealGroupIds ??= new List<int>();
+
+        var dish = await _context.Dishes
+            .Include(d => d.DishProducts)
+            .Include(d => d.MealGroupDishes)
+            .FirstOrDefaultAsync(d => d.Id == id);
+
+        if (dish is null)
+        {
+            return RedirectToPage();
+        }
+
+        dish.Name = EditedDish.Name.Trim();
+        dish.Description = string.IsNullOrWhiteSpace(EditedDish.Description) ? null : EditedDish.Description.Trim();
+        dish.Instructions = string.IsNullOrWhiteSpace(EditedDish.Instructions) ? null : EditedDish.Instructions.Trim();
+        dish.PreparationMinutes = EditedDish.PreparationMinutes;
+        dish.ImageUrl = string.IsNullOrWhiteSpace(EditedDish.ImageUrl) ? null : EditedDish.ImageUrl.Trim();
+
+        var selectedProducts = EditedDish.SelectedProductIds.Distinct().ToHashSet();
+        var selectedGroups = EditedDish.SelectedMealGroupIds.Distinct().ToHashSet();
+
+        foreach (var link in dish.DishProducts.ToList())
+        {
+            if (!selectedProducts.Contains(link.ProductId))
+            {
+                _context.DishProducts.Remove(link);
+            }
+        }
+
+        foreach (var productId in selectedProducts)
+        {
+            if (!dish.DishProducts.Any(dp => dp.ProductId == productId))
+            {
+                dish.DishProducts.Add(new DishProduct { DishId = dish.Id, ProductId = productId });
+            }
+        }
+
+        foreach (var link in dish.MealGroupDishes.ToList())
+        {
+            if (!selectedGroups.Contains(link.MealGroupId))
+            {
+                _context.MealGroupDishes.Remove(link);
+            }
+        }
+
+        foreach (var groupId in selectedGroups)
+        {
+            if (!dish.MealGroupDishes.Any(mg => mg.MealGroupId == groupId))
+            {
+                dish.MealGroupDishes.Add(new MealGroupDish { DishId = dish.Id, MealGroupId = groupId });
+            }
+        }
+
+        await _context.SaveChangesAsync();
+
+        return RedirectToPage(new { focus = id });
     }
 
     private async Task LoadAsync()

--- a/MealMate/wwwroot/css/site.css
+++ b/MealMate/wwwroot/css/site.css
@@ -585,6 +585,132 @@ html, body {
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
+.multiselect {
+  position: relative;
+}
+
+.multiselect__control {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+  min-height: 4.4rem;
+  padding: 0.6rem;
+  border-radius: 1.2rem;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: rgba(255, 255, 255, 0.95);
+  transition: border 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  cursor: text;
+}
+
+.multiselect__control:focus-within,
+.multiselect.is-open .multiselect__control {
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+  background: var(--surface);
+}
+
+.multiselect__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+  padding-left: 0.4rem;
+}
+
+.multiselect__chips:empty::before {
+  content: attr(data-placeholder);
+  color: var(--text-muted);
+  font-size: 1.3rem;
+}
+
+.multiselect__chip {
+  border: none;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.multiselect__chip:hover,
+.multiselect__chip:focus {
+  background: rgba(37, 99, 235, 0.2);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.multiselect__search {
+  flex: 1;
+  min-width: 160px;
+  border: none;
+  padding: 0.6rem 0.8rem;
+  background: transparent;
+  font: inherit;
+}
+
+.multiselect__search:focus {
+  outline: none;
+}
+
+.multiselect__dropdown {
+  display: none;
+  position: absolute;
+  top: calc(100% + 0.6rem);
+  left: 0;
+  right: 0;
+  z-index: 40;
+  background: var(--surface);
+  border-radius: 1.2rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 20px 45px -28px rgba(15, 23, 42, 0.45);
+  max-height: 260px;
+  overflow-y: auto;
+  padding: 0.8rem 0;
+}
+
+.multiselect.is-open .multiselect__dropdown {
+  display: block;
+}
+
+.multiselect__options {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.multiselect__option {
+  padding: 0.9rem 1.6rem;
+  font-size: 1.4rem;
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.multiselect__option:hover,
+.multiselect__option.is-active {
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+}
+
+.multiselect__option.is-hidden {
+  display: none;
+}
+
+.multiselect__empty {
+  padding: 1.2rem 1.6rem;
+  color: var(--text-muted);
+  font-size: 1.3rem;
+}
+
+.multiselect__hidden {
+  display: none;
+}
+
 .validation-errors {
   color: #be123c;
   font-weight: 600;

--- a/MealMate/wwwroot/css/site.css
+++ b/MealMate/wwwroot/css/site.css
@@ -437,7 +437,7 @@ html, body {
 }
 
 .dish-edit-form {
-  display: grid;
+  display: none;
   gap: 1.2rem;
   padding: 1.6rem;
   border-radius: 1.6rem;
@@ -448,6 +448,7 @@ html, body {
 }
 
 .dish-edit-form.is-visible {
+  display: grid;
   animation: fadeInUp 0.22s ease;
 }
 

--- a/MealMate/wwwroot/css/site.css
+++ b/MealMate/wwwroot/css/site.css
@@ -296,63 +296,186 @@ html, body {
   color: var(--text);
 }
 
+
 .dish-list {
-  display: flex;
-  flex-direction: column;
-  gap: 1.2rem;
-}
-
-.dish-item {
   display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 1.2rem;
-  align-items: center;
-  padding: 1.4rem 1.8rem;
-  border-radius: 1.6rem;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(15, 23, 42, 0.05);
+  gap: 1.6rem;
 }
 
-.dish-item.is-focus {
-  border-color: rgba(59, 130, 246, 0.6);
-  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.12);
-}
-
-.dish-meta {
-  display: flex;
-  gap: 0.8rem;
-  align-items: center;
-  color: var(--text-muted);
-  font-size: 1.3rem;
-}
-
-.dish-details {
+.dish-card {
+  position: relative;
+  padding: 2.4rem;
+  border-radius: 2rem;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.75));
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  box-shadow: 0 18px 35px -28px rgba(15, 23, 42, 0.55);
   display: grid;
-  gap: 0.8rem;
+  gap: 1.8rem;
 }
 
-.dish-details details {
-  background: rgba(15, 23, 42, 0.04);
-  padding: 1rem 1.2rem;
-  border-radius: 1.2rem;
-  font-size: 1.3rem;
+.dish-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at top right, rgba(59, 130, 246, 0.18), transparent 55%);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
 }
 
-.chip-column {
+.dish-card.is-focus::before {
+  opacity: 1;
+}
+
+.dish-card.is-focus {
+  border-color: rgba(59, 130, 246, 0.4);
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.12), 0 18px 35px -24px rgba(59, 130, 246, 0.35);
+}
+
+.dish-card__header {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.6rem;
+  position: relative;
+  z-index: 1;
+}
+
+.dish-card__title {
+  display: grid;
   gap: 0.6rem;
-  font-size: 1.3rem;
 }
 
-.chip-column strong {
+.dish-card__title h3 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.dish-card__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 1.35rem;
+  color: var(--text-muted);
+  padding: 0.4rem 1.2rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.1);
+}
+
+.dish-card__actions {
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.ghost-button {
+  border: 1px solid rgba(15, 23, 42, 0.14);
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--text);
+  padding: 0.9rem 1.8rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ghost-button:hover,
+.ghost-button:focus {
+  background: rgba(255, 255, 255, 1);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.4);
+}
+
+.dish-card__body {
+  display: grid;
+  gap: 1.6rem;
+  position: relative;
+  z-index: 1;
+}
+
+.dish-card__description {
+  margin: 0;
+  font-size: 1.45rem;
+  line-height: 1.6;
+  color: var(--text-muted);
+}
+
+.dish-card__tags {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.dish-card__tags strong {
+  display: block;
   font-size: 1.3rem;
+  font-weight: 700;
+  margin-bottom: 0.6rem;
   color: var(--text);
 }
 
-.dish-actions {
+.dish-card__instructions {
+  border-radius: 1.4rem;
+  background: rgba(15, 23, 42, 0.04);
+  padding: 1.2rem 1.6rem;
+  font-size: 1.35rem;
+}
+
+.dish-card__instructions summary {
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.dish-card__instructions p {
+  margin: 0.8rem 0 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.dish-edit-form {
+  display: grid;
+  gap: 1.2rem;
+  padding: 1.6rem;
+  border-radius: 1.6rem;
+  background: rgba(15, 23, 42, 0.035);
+  border: 1px dashed rgba(15, 23, 42, 0.12);
+  position: relative;
+  z-index: 1;
+}
+
+.dish-edit-form.is-visible {
+  animation: fadeInUp 0.22s ease;
+}
+
+.dish-edit-actions {
   display: flex;
-  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 720px) {
+  .dish-card {
+    padding: 2rem;
+  }
+
+  .dish-edit-form {
+    padding: 1.4rem;
+  }
 }
 
 .tag {


### PR DESCRIPTION
## Summary
- restyled the dish list into modern cards with clearer product and group breakdowns
- added inline edit forms with toggles so dishes can be updated without leaving the page
- wired server-side update handler to persist name, description, instructions, and associations

## Testing
- dotnet build *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de8413a50883308ef283458a05e0eb